### PR TITLE
Pin third-party GitHub Actions versions with Full Changeset Hash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "10:00"
+      timezone: "Asia/Tokyo"

--- a/.github/workflows/mssql-with-tbls.yml
+++ b/.github/workflows/mssql-with-tbls.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup tbls
-        uses: k1low/setup-tbls@v1
+        uses: k1low/setup-tbls@bc3b2e35bfff08e10d3d79dff8d9b5ce28b766b7 # v1.3.0
 
       - name: Install sqlcmd
         run: |

--- a/.github/workflows/mysql-with-tbls.yml
+++ b/.github/workflows/mysql-with-tbls.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup tbls
-        uses: k1low/setup-tbls@v1
+        uses: k1low/setup-tbls@bc3b2e35bfff08e10d3d79dff8d9b5ce28b766b7 # v1.3.0
 
       - name: Migrate schema
         run: |

--- a/.github/workflows/prisma-with-cloudflare-pages.yml
+++ b/.github/workflows/prisma-with-cloudflare-pages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Generate ER Diagrams
         run: npx @liam-hq/cli erd build --input prisma/schema.prisma --format prisma
       - name: Deploy ERD to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN_SAMPLE_PRISMA }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_SAMPLE_PRISMA }}

--- a/.github/workflows/rails-8-0-db-structure.yml
+++ b/.github/workflows/rails-8-0-db-structure.yml
@@ -31,7 +31,7 @@ jobs:
 
       # NOTE: for `bin/rails` command.
       - name: Setup Ruby for samples/rails-8-0-db-structure
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1.226.0
         with:
           bundler-cache: true
           working-directory: samples/rails-8-0-db-structure

--- a/.github/workflows/rails-add-association-foreign-key.yml
+++ b/.github/workflows/rails-add-association-foreign-key.yml
@@ -31,7 +31,7 @@ jobs:
 
       # NOTE: for `bin/rails` command.
       - name: Setup Ruby for samples/rails-add-association-foreign-key
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1.226.0
         with:
           bundler-cache: true
           working-directory: samples/rails-add-association-foreign-key


### PR DESCRIPTION
## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
To mitigate the risk of third-party GitHub Actions being compromised with malware, I are now pinning their versions using Full Changeset Hashes.

Previously, some GitHub Actions were pinned to major versions like v2, allowing for loose version upgrades. With this change, such automatic upgrades will no longer occur. Instead, I will use Dependabot version updates to update them once a month.

## What would you like reviewers to focus on?
<!-- What specific aspects are you requesting review for? -->
* We will not pin the versions of official GitHub Actions using Full Changeset Hashes
* This PR does not upgrade any GitHub Actions
    * Using https://github.com/suzuki-shunsuke/pinact
* We will introduce Dependabot version updates to update GitHub Actions once a month

## Additional Notes

> * Using https://github.com/suzuki-shunsuke/pinact

1. Create .pinact.yaml

    ```console
    pinact init
    ```

2. Edit .pinact.yaml

    ```diff
    --- .pinact.yaml.bak	2025-03-17 15:54:33
    +++ .pinact.yaml	2025-03-17 15:54:24
    @@ -5,5 +5,5 @@
       - pattern: "^(.*/)?action\\.ya?ml$"
     
     ignore_actions:
    -# - name: actions/checkout
    -# - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
    +  - name: actions/checkout
    +  - name: actions/setup-python
    ```

3. Update .github/workflows/*.yml

    ```console
    pinact run
    ```

4. Verify version annotations

    ```console
    pinact run --verify
    ```
